### PR TITLE
rpc: getnetmsgstats phase III (new commit history)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2679,6 +2679,12 @@ void CConnman::RecordBytesSent(uint64_t bytes)
     nMaxOutboundTotalBytesSentInCycle += bytes;
 }
 
+CConnman::NetStats CConnman::GetNetStats() const
+{
+    return m_net_stats;
+}
+
+
 uint64_t CConnman::GetMaxOutboundTarget() const
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -104,8 +104,6 @@ enum BindFlags {
 // The sleep time needs to be small to avoid new sockets stalling
 static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 50;
 
-const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
-
 static const uint64_t RANDOMIZER_ID_NETGROUP = 0x6c0edd8036ef4036ULL; // SHA256("netgroup")[0:8]
 static const uint64_t RANDOMIZER_ID_LOCALHOSTNONCE = 0xd93e69e2bbfa5735ULL; // SHA256("localhostnonce")[0:8]
 static const uint64_t RANDOMIZER_ID_ADDRCACHE = 0x1cf2e4ddd306dda9ULL; // SHA256("addrcache")[0:8]

--- a/src/net.h
+++ b/src/net.h
@@ -183,7 +183,6 @@ struct LocalServiceInfo {
 extern GlobalMutex g_maplocalhost_mutex;
 extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
 
-extern const std::string NET_MESSAGE_TYPE_OTHER;
 using mapMsgTypeSize = std::map</* message type */ std::string, /* total bytes */ uint64_t>;
 
 class CNodeStats

--- a/src/net.h
+++ b/src/net.h
@@ -859,6 +859,16 @@ public:
     // Number of elements in `Direction`.
     static constexpr size_t NUM_DIRECTIONS{2};
 
+    struct MsgStatsValue {
+        int msg_count;
+        uint64_t byte_count;
+    };
+
+    using Stats = std::array<std::array<std::array<std::array<MsgStatsValue, NUM_NET_MESSAGE_TYPES + 1>, // add 1 for the other message type
+                                                   NUM_CONNECTION_TYPES>,
+                                        NET_MAX>,
+                             NUM_DIRECTIONS>;
+
     /** Get a unique deterministic randomizer. */
     CSipHasher GetDeterministicRandomizer(uint64_t id) const;
 

--- a/src/net.h
+++ b/src/net.h
@@ -854,6 +854,11 @@ public:
     uint64_t GetTotalBytesRecv() const;
     uint64_t GetTotalBytesSent() const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
 
+    enum class Direction { SENT, RECV };
+
+    // Number of elements in `Direction`.
+    static constexpr size_t NUM_DIRECTIONS{2};
+
     /** Get a unique deterministic randomizer. */
     CSipHasher GetDeterministicRandomizer(uint64_t id) const;
 

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -13,7 +13,8 @@
  *
  * If adding or removing types, please update CONNECTION_TYPE_DOC in
  * src/rpc/net.cpp and src/qt/rpcconsole.cpp, as well as the descriptions in
- * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler. */
+ * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler and
+ * NUM_CONNECTION_TYPES below. */
 enum class ConnectionType {
     /**
      * Inbound connections are those initiated by a peer. This is the only
@@ -75,6 +76,9 @@ enum class ConnectionType {
      */
     ADDR_FETCH,
 };
+
+/** Number of entries in ConnectionType. */
+static constexpr size_t NUM_CONNECTION_TYPES{6};
 
 /** Convert ConnectionType enum to a string value */
 std::string ConnectionTypeAsString(ConnectionType conn_type);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -89,6 +89,9 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
 };
+
+static_assert(NUM_NET_MESSAGE_TYPES == sizeof(allNetMessageTypes) / sizeof(allNetMessageTypes[0]), "Please update NUM_NET_MESSAGE_TYPES");
+
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -188,6 +188,20 @@ const std::vector<std::string> &getAllNetMessageTypes()
     return allNetMessageTypesVec;
 }
 
+int getMessageTypeIndex(std::string msg_type)
+{
+    const std::vector<std::string>& message_types = getAllNetMessageTypes();
+    auto msg_type_itr = std::find(message_types.begin(), message_types.end(), msg_type);
+
+    if (msg_type_itr != message_types.end()) {
+        int index = msg_type_itr - message_types.begin();
+        return index;
+    } else {
+        // assign the last index to be a catch all for NET_MESSAGE_TYPE_OTHER
+        return NUM_NET_MESSAGE_TYPES;
+    }
+}
+
 /**
  * Convert a service flag (NODE_*) to a human readable string.
  * It supports unknown service flags which will be returned as "UNKNOWN[...]".

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,6 +47,8 @@ const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 } // namespace NetMsgType
 
+const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
+
 /** All known message types. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -266,6 +266,8 @@ extern const char* WTXIDRELAY;
 extern const char* SENDTXRCNCL;
 }; // namespace NetMsgType
 
+extern const std::string NET_MESSAGE_TYPE_OTHER;
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -268,6 +268,9 @@ extern const char* SENDTXRCNCL;
 
 extern const std::string NET_MESSAGE_TYPE_OTHER;
 
+/* Number of entries in allNetMessageTypes in protocol.cpp */
+constexpr size_t NUM_NET_MESSAGE_TYPES = 35;
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -274,6 +274,9 @@ constexpr size_t NUM_NET_MESSAGE_TYPES = 35;
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 
+/* Get the index of a message type from the vector of all message types*/
+int getMessageTypeIndex(std::string msg_type);
+
 /** nServices flags */
 enum ServiceFlags : uint64_t {
     // NOTE: When adding here, be sure to update serviceFlagToStr too

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -171,6 +171,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
+    { "getnetmsgstats", 0, "filters"},
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1173,3 +1173,16 @@ UniValue GetServicesNames(ServiceFlags services)
 
     return servicesNames;
 }
+
+StatsFilter StringToStatsFilter(std::string stats_filter)
+{
+    if (stats_filter == "msgtype") {
+        return StatsFilter::MESSAGE_TYPE;
+    } else if (stats_filter == "conntype") {
+        return StatsFilter::CONNECTION_TYPE;
+    } else if (stats_filter == "network") {
+        return StatsFilter::NETWORK_TYPE;
+    } else {
+        return StatsFilter::DIRECTION;
+    }
+}

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -451,4 +451,6 @@ enum class StatsFilter {
     DIRECTION,
 };
 
+StatsFilter StringToStatsFilter(std::string stats_filter);
+
 #endif // BITCOIN_RPC_UTIL_H


### PR DESCRIPTION
This PR reflects phase III of my work for https://github.com/bitcoin/bitcoin/issues/26337

It includes a new `getnetmsgstats` RPC, which supports several kinds of filters (msgtype, conntype, network, etc.) in any order. 

**_Phases_**

- **_Phase I - PR https://github.com/satsie/bitcoin/pull/2_** 
Extend the `getnettotals` RPC to return a breakdown of bytes per message type. This breakdown is returned in the `bytessent_per_msg` part of the response.
- **_Phase II - PR https://github.com/satsie/bitcoin/pull/3_** 
Move the code from Phase I to a new RPC, `getnetmsgstats`. Index network message stats by message type x network type x connection type. Use two data structures for this, one for sent messages and one for received. Also work through the algorithm needed to aggregate stats by one or more filters.
- **_Phase III - (this PR!)_** 
Clean commit history. Prepare to share with a wider audience and seek feedback before opening a PR to Bitcoin Core. Still have some unresolved questions of my own that I have left as comments and hope to get input on.  


**_Examples_**

Below are some examples on how the new `getnetmsgstats` RPC can be used. 

<details>
  <summary>getnetmsgstats</summary>

```
 ./src/bitcoin-cli getnetmsgstats
{
  "sent": {
    "total": {
      "msg_count": 175,
      "total_bytes": 34109
    }
  },
  "received": {
    "total": {
      "msg_count": 280,
      "total_bytes": 2144499
    }
  }
}
```
</details>

<details>
<summary>getnetmsgstats '["conntype","msgtype"]'</summary>

```
./src/bitcoin-cli getnetmsgstats '["conntype","msgtype"]'
{
  "sent": {
    "block-relay-only": {
      "getheaders": {
        "msg_count": 5,
        "total_bytes": 5265
      },
      "headers": {
        "msg_count": 4,
        "total_bytes": 424
      },
      "inv": {
        "msg_count": 1,
        "total_bytes": 61
      },
      "ping": {
        "msg_count": 5,
        "total_bytes": 160
      },
      "pong": {
        "msg_count": 3,
        "total_bytes": 96
      },
      "sendaddrv2": {
        "msg_count": 4,
        "total_bytes": 96
      },
      "sendcmpct": {
        "msg_count": 5,
        "total_bytes": 165
      },
      "sendheaders": {
        "msg_count": 2,
        "total_bytes": 48
      },
      "verack": {
        "msg_count": 5,
        "total_bytes": 120
      },
      "version": {
        "msg_count": 5,
        "total_bytes": 635
      },
      "wtxidrelay": {
        "msg_count": 4,
        "total_bytes": 96
      }
    },
    "outbound-full-relay": {
      "addr": {
        "msg_count": 3,
        "total_bytes": 165
      },
      "addrv2": {
        "msg_count": 10,
        "total_bytes": 452
      },
      "feefilter": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "getaddr": {
        "msg_count": 9,
        "total_bytes": 216
      },
      "getblocktxn": {
        "msg_count": 2,
        "total_bytes": 4027
      },
      "getdata": {
        "msg_count": 120,
        "total_bytes": 24312
      },
      "getheaders": {
        "msg_count": 9,
        "total_bytes": 9477
      },
      "headers": {
        "msg_count": 11,
        "total_bytes": 1004
      },
      "inv": {
        "msg_count": 222,
        "total_bytes": 87378
      },
      "ping": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "pong": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "sendaddrv2": {
        "msg_count": 7,
        "total_bytes": 168
      },
      "sendcmpct": {
        "msg_count": 11,
        "total_bytes": 363
      },
      "sendheaders": {
        "msg_count": 8,
        "total_bytes": 192
      },
      "tx": {
        "msg_count": 14,
        "total_bytes": 3510
      },
      "verack": {
        "msg_count": 9,
        "total_bytes": 216
      },
      "version": {
        "msg_count": 10,
        "total_bytes": 1270
      },
      "wtxidrelay": {
        "msg_count": 7,
        "total_bytes": 168
      }
    }
  },
  "received": {
    "block-relay-only": {
      "feefilter": {
        "msg_count": 2,
        "total_bytes": 64
      },
      "getheaders": {
        "msg_count": 3,
        "total_bytes": 3159
      },
      "headers": {
        "msg_count": 3,
        "total_bytes": 237
      },
      "inv": {
        "msg_count": 1,
        "total_bytes": 133
      },
      "ping": {
        "msg_count": 3,
        "total_bytes": 96
      },
      "pong": {
        "msg_count": 3,
        "total_bytes": 96
      },
      "sendaddrv2": {
        "msg_count": 3,
        "total_bytes": 72
      },
      "sendcmpct": {
        "msg_count": 5,
        "total_bytes": 165
      },
      "sendheaders": {
        "msg_count": 3,
        "total_bytes": 72
      },
      "verack": {
        "msg_count": 5,
        "total_bytes": 120
      },
      "version": {
        "msg_count": 5,
        "total_bytes": 631
      },
      "wtxidrelay": {
        "msg_count": 3,
        "total_bytes": 72
      }
    },
    "outbound-full-relay": {
      "addr": {
        "msg_count": 4,
        "total_bytes": 60164
      },
      "addrv2": {
        "msg_count": 15,
        "total_bytes": 110294
      },
      "blocktxn": {
        "msg_count": 2,
        "total_bytes": 4600726
      },
      "cmpctblock": {
        "msg_count": 3,
        "total_bytes": 37593
      },
      "feefilter": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "getdata": {
        "msg_count": 11,
        "total_bytes": 779
      },
      "getheaders": {
        "msg_count": 9,
        "total_bytes": 9477
      },
      "headers": {
        "msg_count": 14,
        "total_bytes": 1484
      },
      "inv": {
        "msg_count": 135,
        "total_bytes": 61155
      },
      "notfound": {
        "msg_count": 1,
        "total_bytes": 277
      },
      "ping": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "pong": {
        "msg_count": 9,
        "total_bytes": 288
      },
      "sendaddrv2": {
        "msg_count": 8,
        "total_bytes": 192
      },
      "sendcmpct": {
        "msg_count": 16,
        "total_bytes": 528
      },
      "sendheaders": {
        "msg_count": 9,
        "total_bytes": 216
      },
      "tx": {
        "msg_count": 583,
        "total_bytes": 395235
      },
      "verack": {
        "msg_count": 10,
        "total_bytes": 240
      },
      "version": {
        "msg_count": 10,
        "total_bytes": 1276
      },
      "wtxidrelay": {
        "msg_count": 8,
        "total_bytes": 192
      }
    }
  }
}

```
</details>

<details>
<summary>getnetmsgstats '["conntype", "network", "msgtype"]'</summary>

```
./src/bitcoin-cli getnetmsgstats '["conntype", "network", "msgtype"]'
{
  "sent": {
    "block-relay-only": {
      "ipv4": {
        "getheaders": {
          "msg_count": 5,
          "total_bytes": 5265
        },
        "headers": {
          "msg_count": 4,
          "total_bytes": 424
        },
        "inv": {
          "msg_count": 1,
          "total_bytes": 61
        },
        "ping": {
          "msg_count": 6,
          "total_bytes": 192
        },
        "pong": {
          "msg_count": 4,
          "total_bytes": 128
        },
        "sendaddrv2": {
          "msg_count": 4,
          "total_bytes": 96
        },
        "sendcmpct": {
          "msg_count": 5,
          "total_bytes": 165
        },
        "sendheaders": {
          "msg_count": 2,
          "total_bytes": 48
        },
        "verack": {
          "msg_count": 5,
          "total_bytes": 120
        },
        "version": {
          "msg_count": 5,
          "total_bytes": 635
        },
        "wtxidrelay": {
          "msg_count": 4,
          "total_bytes": 96
        }
      }
    },
    "outbound-full-relay": {
      "ipv4": {
        "addr": {
          "msg_count": 6,
          "total_bytes": 360
        },
        "addrv2": {
          "msg_count": 15,
          "total_bytes": 868
        },
        "feefilter": {
          "msg_count": 9,
          "total_bytes": 288
        },
        "getaddr": {
          "msg_count": 9,
          "total_bytes": 216
        },
        "getblocktxn": {
          "msg_count": 2,
          "total_bytes": 4027
        },
        "getdata": {
          "msg_count": 210,
          "total_bytes": 42978
        },
        "getheaders": {
          "msg_count": 9,
          "total_bytes": 9477
        },
        "headers": {
          "msg_count": 11,
          "total_bytes": 1004
        },
        "inv": {
          "msg_count": 431,
          "total_bytes": 175079
        },
        "ping": {
          "msg_count": 17,
          "total_bytes": 544
        },
        "pong": {
          "msg_count": 17,
          "total_bytes": 544
        },
        "sendaddrv2": {
          "msg_count": 7,
          "total_bytes": 168
        },
        "sendcmpct": {
          "msg_count": 11,
          "total_bytes": 363
        },
        "sendheaders": {
          "msg_count": 8,
          "total_bytes": 192
        },
        "tx": {
          "msg_count": 59,
          "total_bytes": 41631
        },
        "verack": {
          "msg_count": 9,
          "total_bytes": 216
        },
        "version": {
          "msg_count": 10,
          "total_bytes": 1270
        },
        "wtxidrelay": {
          "msg_count": 7,
          "total_bytes": 168
        }
      }
    }
  },
  "received": {
    "block-relay-only": {
      "ipv4": {
        "feefilter": {
          "msg_count": 2,
          "total_bytes": 64
        },
        "getheaders": {
          "msg_count": 3,
          "total_bytes": 3159
        },
        "headers": {
          "msg_count": 3,
          "total_bytes": 237
        },
        "inv": {
          "msg_count": 1,
          "total_bytes": 133
        },
        "ping": {
          "msg_count": 4,
          "total_bytes": 128
        },
        "pong": {
          "msg_count": 4,
          "total_bytes": 128
        },
        "sendaddrv2": {
          "msg_count": 3,
          "total_bytes": 72
        },
        "sendcmpct": {
          "msg_count": 5,
          "total_bytes": 165
        },
        "sendheaders": {
          "msg_count": 3,
          "total_bytes": 72
        },
        "verack": {
          "msg_count": 5,
          "total_bytes": 120
        },
        "version": {
          "msg_count": 5,
          "total_bytes": 631
        },
        "wtxidrelay": {
          "msg_count": 3,
          "total_bytes": 72
        }
      }
    },
    "outbound-full-relay": {
      "ipv4": {
        "addr": {
          "msg_count": 5,
          "total_bytes": 60219
        },
        "addrv2": {
          "msg_count": 23,
          "total_bytes": 110809
        },
        "blocktxn": {
          "msg_count": 2,
          "total_bytes": 4600726
        },
        "cmpctblock": {
          "msg_count": 3,
          "total_bytes": 37593
        },
        "feefilter": {
          "msg_count": 9,
          "total_bytes": 288
        },
        "getdata": {
          "msg_count": 42,
          "total_bytes": 3174
        },
        "getheaders": {
          "msg_count": 9,
          "total_bytes": 9477
        },
        "headers": {
          "msg_count": 14,
          "total_bytes": 1484
        },
        "inv": {
          "msg_count": 243,
          "total_bytes": 109647
        },
        "notfound": {
          "msg_count": 1,
          "total_bytes": 277
        },
        "ping": {
          "msg_count": 17,
          "total_bytes": 544
        },
        "pong": {
          "msg_count": 17,
          "total_bytes": 544
        },
        "sendaddrv2": {
          "msg_count": 8,
          "total_bytes": 192
        },
        "sendcmpct": {
          "msg_count": 16,
          "total_bytes": 528
        },
        "sendheaders": {
          "msg_count": 9,
          "total_bytes": 216
        },
        "tx": {
          "msg_count": 1039,
          "total_bytes": 1225891
        },
        "verack": {
          "msg_count": 10,
          "total_bytes": 240
        },
        "version": {
          "msg_count": 10,
          "total_bytes": 1276
        },
        "wtxidrelay": {
          "msg_count": 8,
          "total_bytes": 192
        }
      }
    }
  }
}
```
</details>

Over the coming days/weeks while this PR is open I will be re-reading the contributor guidelines and will be making some hopefully just minor updates in addition to whatever feedback comes in.



