### PR TITLE
rpc: getnetmsgstats revision IV

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2695,6 +2695,83 @@ void CConnman::RecordBytesSent(uint64_t bytes)
     nMaxOutboundTotalBytesSentInCycle += bytes;
 }
 
+NetStats::Direction NetStats::DirectionFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return Direction::SENT;
+    case 1: return Direction::RECV;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::DirectionToIndex(Direction direction)
+{
+    switch (direction) {
+    case Direction::SENT: return 0;
+    case Direction::RECV: return 1;
+    }
+
+    assert(false);
+}
+
+Network NetStats::NetworkFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return Network::NET_UNROUTABLE;
+    case 1: return Network::NET_IPV4;
+    case 2: return Network::NET_IPV6;
+    case 3: return Network::NET_ONION;
+    case 4: return Network::NET_I2P;
+    case 5: return Network::NET_CJDNS;
+    case 6: return Network::NET_INTERNAL;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::NetworkToIndex(Network net)
+{
+    switch (net) {
+    case Network::NET_UNROUTABLE: return 0;
+    case Network::NET_IPV4: return 1;
+    case Network::NET_IPV6: return 2;
+    case Network::NET_ONION: return 3;
+    case Network::NET_I2P: return 4;
+    case Network::NET_CJDNS: return 5;
+    case Network::NET_INTERNAL: return 6;
+    case Network::NET_MAX: assert(false);
+    }
+    assert(false);
+}
+
+ConnectionType NetStats::ConnectionTypeFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return ConnectionType::INBOUND;
+    case 1: return ConnectionType::OUTBOUND_FULL_RELAY;
+    case 2: return ConnectionType::MANUAL;
+    case 3: return ConnectionType::FEELER;
+    case 4: return ConnectionType::BLOCK_RELAY;
+    case 5: return ConnectionType::ADDR_FETCH;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
+{
+    switch (conn_type) {
+    case ConnectionType::INBOUND: return 0;
+    case ConnectionType::OUTBOUND_FULL_RELAY: return 1;
+    case ConnectionType::MANUAL: return 2;
+    case ConnectionType::FEELER: return 3;
+    case ConnectionType::BLOCK_RELAY: return 4;
+    case ConnectionType::ADDR_FETCH: return 5;
+    }
+    assert(false);
+}
+
 uint64_t CConnman::GetMaxOutboundTarget() const
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -105,8 +105,6 @@ enum BindFlags {
 // The sleep time needs to be small to avoid new sockets stalling
 static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 50;
 
-const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
-
 static const uint64_t RANDOMIZER_ID_NETGROUP = 0x6c0edd8036ef4036ULL; // SHA256("netgroup")[0:8]
 static const uint64_t RANDOMIZER_ID_LOCALHOSTNONCE = 0xd93e69e2bbfa5735ULL; // SHA256("localhostnonce")[0:8]
 static const uint64_t RANDOMIZER_ID_ADDRCACHE = 0x1cf2e4ddd306dda9ULL; // SHA256("addrcache")[0:8]

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2793,6 +2793,18 @@ size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
     assert(false);
 }
 
+std::string NetStats::DirectionAsString(Direction direction)
+{
+    switch (direction) {
+    case Direction::SENT:
+        return "sent";
+    case Direction::RECV:
+        return "received";
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
 uint64_t CConnman::GetMaxOutboundTarget() const
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -344,6 +344,40 @@ public:
     void prepareForTransport(CSerializedNetMsg& msg, std::vector<unsigned char>& header) const override;
 };
 
+/**
+ * Placeholder for total network traffic. Split by direction, network, connection
+ * type and message type (byte and message counts).
+ */
+class NetStats
+{
+public:
+    struct MsgStat {
+        std::atomic_uint64_t byte_count; //!< Number of bytes transferred.
+        std::atomic_uint64_t msg_count;  //!< Number of messages transferred.
+
+        MsgStat() : byte_count{0}, msg_count{0} {}
+
+        MsgStat(const MsgStat& x) : byte_count{x.byte_count.load()}, msg_count{x.msg_count.load()} {}
+
+        MsgStat(std::atomic_uint64_t x, std::atomic_uint64_t y) : byte_count{x.load()}, msg_count{y.load()} {}
+    };
+
+    enum class Direction { SENT,
+                            RECV };
+
+    /// Number of elements in `Direction`.
+    static constexpr size_t NUM_DIRECTIONS{2};
+
+    using MultiDimensionalStats = std::array<std::array<std::array<std::array<MsgStat,
+                                                                                // add 1 for the other message type
+                                                                                NUM_NET_MESSAGE_TYPES + 1>,
+                                                                    NUM_CONNECTION_TYPES>,
+                                                        NET_MAX>,
+                                                NUM_DIRECTIONS>;
+
+    MultiDimensionalStats m_data;
+};
+
 struct CNodeOptions
 {
     NetPermissionFlags permission_flags = NetPermissionFlags::None;

--- a/src/net.h
+++ b/src/net.h
@@ -183,7 +183,6 @@ struct LocalServiceInfo {
 extern GlobalMutex g_maplocalhost_mutex;
 extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
 
-extern const std::string NET_MESSAGE_TYPE_OTHER;
 using mapMsgTypeSize = std::map</* message type */ std::string, /* total bytes */ uint64_t>;
 
 class CNodeStats

--- a/src/net.h
+++ b/src/net.h
@@ -415,6 +415,8 @@ public:
     [[nodiscard]] static Network NetworkFromIndex(size_t index);
     [[nodiscard]] static ConnectionType ConnectionTypeFromIndex(size_t index);
 
+    static std::string DirectionAsString(Direction direction);
+
 private:
     // Helper methods to make sure the indexes associated with enums are reliable
     [[nodiscard]] static size_t DirectionToIndex(Direction direction);

--- a/src/net.h
+++ b/src/net.h
@@ -376,6 +376,21 @@ public:
                                                 NUM_DIRECTIONS>;
 
     MultiDimensionalStats m_data;
+
+    // The ...FromIndex() and ...ToIndex() methods below convert from/to
+    // indexes of `m_data[]` to the actual values they represent. For example,
+    // assuming MessageTypeToIndex("ping") == 15, then everything stored in
+    // m_data[x][y][z][15] is traffic from "ping" messages (for any x, y or z).
+
+    [[nodiscard]] static Direction DirectionFromIndex(size_t index);
+    [[nodiscard]] static Network NetworkFromIndex(size_t index);
+    [[nodiscard]] static ConnectionType ConnectionTypeFromIndex(size_t index);
+
+private:
+    // Helper methods to make sure the indexes associated with enums are reliable
+    [[nodiscard]] static size_t DirectionToIndex(Direction direction);
+    [[nodiscard]] static size_t NetworkToIndex(Network net);
+    [[nodiscard]] static size_t ConnectionTypeToIndex(ConnectionType conn_type);
 };
 
 struct CNodeOptions

--- a/src/net.h
+++ b/src/net.h
@@ -377,6 +377,35 @@ public:
 
     MultiDimensionalStats m_data;
 
+    void Init()
+    {
+        for (std::size_t direction_index = 0; direction_index < NUM_DIRECTIONS; direction_index++) {
+            for (int network_index = 0; network_index < NET_MAX; network_index++) {
+                for (std::size_t connection_index = 0; connection_index < NUM_CONNECTION_TYPES; connection_index++) {
+                    for (std::size_t message_index = 0; message_index < NUM_NET_MESSAGE_TYPES + 1; message_index++) {
+                        // +1 for the "other" message type
+                        auto& stat = m_data.at(direction_index)
+                                           .at(network_index)
+                                           .at(connection_index)
+                                           .at(message_index);
+
+                        stat.msg_count = 0;
+                        stat.byte_count = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Increment the amount of bytes transferred by `bytes` and the amount of messages by 1.
+     */
+    void Record(Direction direction,
+                Network net,
+                ConnectionType conn_type,
+                const std::string& msg_type,
+                size_t byte_count);
+
     // The ...FromIndex() and ...ToIndex() methods below convert from/to
     // indexes of `m_data[]` to the actual values they represent. For example,
     // assuming MessageTypeToIndex("ping") == 15, then everything stored in
@@ -469,8 +498,10 @@ public:
 
     const ConnectionType m_conn_type;
 
-    /** Move all messages from the received queue to the processing queue. */
-    void MarkReceivedMsgsForProcessing()
+    /** Move all messages from the received queue to the processing queue.
+     * Also update the global map of network message statistics.
+     */
+    void MarkReceivedMsgsForProcessing(NetStats& net_stats)
         EXCLUSIVE_LOCKS_REQUIRED(!m_msg_process_queue_mutex);
 
     /** Poll the next message from the processing queue of this connection.
@@ -799,6 +830,7 @@ public:
             m_added_nodes = connOptions.m_added_nodes;
         }
         m_onion_binds = connOptions.onion_binds;
+        m_net_stats.Init();
     }
 
     CConnman(uint64_t seed0, uint64_t seed1, AddrMan& addrman, const NetGroupManager& netgroupman,
@@ -939,6 +971,8 @@ public:
     /** Return true if we should disconnect the peer for failing an inactivity check. */
     bool ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const;
 
+    NetStats GetNetStats() const;
+
 private:
     struct ListenSocket {
     public:
@@ -1063,6 +1097,8 @@ private:
     mutable Mutex m_total_bytes_sent_mutex;
     std::atomic<uint64_t> nTotalBytesRecv{0};
     uint64_t nTotalBytesSent GUARDED_BY(m_total_bytes_sent_mutex) {0};
+
+    NetStats m_net_stats;
 
     // outbound limit & stats
     uint64_t nMaxOutboundTotalBytesSentInCycle GUARDED_BY(m_total_bytes_sent_mutex) {0};

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -13,7 +13,8 @@
  *
  * If adding or removing types, please update CONNECTION_TYPE_DOC in
  * src/rpc/net.cpp and src/qt/rpcconsole.cpp, as well as the descriptions in
- * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler. */
+ * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler and
+ * NUM_CONNECTION_TYPES below. */
 enum class ConnectionType {
     /**
      * Inbound connections are those initiated by a peer. This is the only
@@ -75,6 +76,9 @@ enum class ConnectionType {
      */
     ADDR_FETCH,
 };
+
+/** Number of entries in ConnectionType. */
+static constexpr size_t NUM_CONNECTION_TYPES{6};
 
 /** Convert ConnectionType enum to a string value */
 std::string ConnectionTypeAsString(ConnectionType conn_type);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -190,6 +190,29 @@ const std::vector<std::string> &getAllNetMessageTypes()
     return allNetMessageTypesVec;
 }
 
+int messageTypeToIndex(const std::string& msg_type)
+{
+    const std::vector<std::string>& message_types = getAllNetMessageTypes();
+    auto msg_type_itr = std::find(message_types.begin(), message_types.end(), msg_type);
+
+    if (msg_type_itr != message_types.end()) {
+        int index = msg_type_itr - message_types.begin();
+        return index;
+    } else {
+        // assign the last index to be a catch all for NET_MESSAGE_TYPE_OTHER
+        return NUM_NET_MESSAGE_TYPES;
+    }
+}
+
+const std::string& messageTypeFromIndex(size_t index)
+{
+    if (index == NUM_NET_MESSAGE_TYPES) {
+        return NET_MESSAGE_TYPE_OTHER;
+    }
+
+    return getAllNetMessageTypes().at(index);
+}
+
 /**
  * Convert a service flag (NODE_*) to a human readable string.
  * It supports unknown service flags which will be returned as "UNKNOWN[...]".

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -49,6 +49,8 @@ const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 } // namespace NetMsgType
 
+const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
+
 /** All known message types. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -91,6 +91,9 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
 };
+
+static_assert(NUM_NET_MESSAGE_TYPES == sizeof(allNetMessageTypes) / sizeof(allNetMessageTypes[0]), "Please update NUM_NET_MESSAGE_TYPES");
+
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -266,6 +266,8 @@ extern const char* WTXIDRELAY;
 extern const char* SENDTXRCNCL;
 }; // namespace NetMsgType
 
+extern const std::string NET_MESSAGE_TYPE_OTHER;
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -268,6 +268,9 @@ extern const char* SENDTXRCNCL;
 
 extern const std::string NET_MESSAGE_TYPE_OTHER;
 
+/* Number of entries in allNetMessageTypes in protocol.cpp */
+static constexpr size_t NUM_NET_MESSAGE_TYPES{35};
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -274,6 +274,12 @@ static constexpr size_t NUM_NET_MESSAGE_TYPES{35};
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 
+/* Get the index of a message type from the vector of all message types */
+int messageTypeToIndex(const std::string& msg_type);
+
+/* Get the string value of a message type from an index */
+const std::string& messageTypeFromIndex(size_t index);
+
 /** nServices flags */
 enum ServiceFlags : uint64_t {
     // NOTE: When adding here, be sure to update serviceFlagToStr too

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -172,6 +172,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
+    { "getnetmsgstats", 0, "show_only"},
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -9,6 +9,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <core_io.h>
+#include <net.h>
 #include <net_permissions.h>
 #include <net_processing.h>
 #include <net_types.h> // For banmap_t
@@ -21,6 +22,7 @@
 #include <rpc/util.h>
 #include <sync.h>
 #include <timedata.h>
+#include <util/overloaded.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>
@@ -508,6 +510,214 @@ static RPCHelpMan getaddednodeinfo()
 },
     };
 }
+
+namespace net_stats {
+
+enum class DimensionType {
+    CONNECTION_TYPE,
+    DIRECTION,
+    MESSAGE_TYPE,
+    NETWORK_TYPE,
+    NONE,
+};
+
+DimensionType StringToDimensionType(std::string dimension)
+{
+    if (dimension == "message_type") {
+        return DimensionType::MESSAGE_TYPE;
+    } else if (dimension == "connection_type") {
+        return DimensionType::CONNECTION_TYPE;
+    } else if (dimension == "network") {
+        return DimensionType::NETWORK_TYPE;
+    } else if (dimension == "direction") {
+        return DimensionType::DIRECTION;
+    }
+
+    return DimensionType::NONE;
+}
+
+class MultiLevelStatsMap
+{
+private:
+    size_t m_levels = 0;
+    std::variant<
+        std::map<std::string, NetStats::MsgStat>,
+        std::map<std::string, MultiLevelStatsMap>>
+        m_varmap;
+
+public:
+    explicit MultiLevelStatsMap(size_t levels) : m_levels{levels}
+    {
+        if (levels > 1) {
+            m_varmap.emplace<1>();
+        } else {
+            m_varmap.emplace<0>();
+        }
+    }
+
+    NetStats::MsgStat* get_value(const Span<std::string>& steps)
+    {
+        if (steps.size() == 0) return nullptr;
+        return std::visit(util::Overloaded{
+                              [&](std::map<std::string, NetStats::MsgStat>& m) {
+                                  return &m[steps.front()]; // create if not present
+                              },
+                              [&](std::map<std::string, MultiLevelStatsMap>& m) {
+                                  size_t sublevel = m_levels > 0 ? m_levels - 1 : 0;
+                                  auto [it, inserted] = m.try_emplace(steps.front(), sublevel);
+                                  return it->second.get_value(steps.subspan(1));
+                              }},
+                          m_varmap);
+    }
+
+    UniValue to_univalue() const
+    {
+        UniValue result(UniValue::VOBJ);
+        std::visit(util::Overloaded{
+                       [&](const std::map<std::string, NetStats::MsgStat>& m) {
+                           for (auto& [k, v] : m) {
+                               if (v.msg_count > 0) {
+                                   UniValue msg_stats(UniValue::VOBJ);
+                                   msg_stats.pushKV("message_count", v.msg_count.load());
+                                   msg_stats.pushKV("byte_count", v.byte_count.load());
+                                   result.pushKV(k, msg_stats);
+                               }
+                           }
+                       },
+                       [&](const std::map<std::string, MultiLevelStatsMap>& m) {
+                           for (auto& [k, v] : m) {
+                               UniValue v_univalue = v.to_univalue();
+                               if (v_univalue.size() > 0) {
+                                   result.pushKV(k, v_univalue);
+                               }
+                           }
+                       }},
+                   m_varmap);
+        return result;
+    }
+};
+
+/**
+ * Arrange the stats in `stats.m_data` according to the `dimension_types`. Sum all the
+ * data for dimensions that are not listed.
+ * @code
+ * sent                      recv                      (direction)
+ * ||___________             ||___________
+ * |            |            |            |
+ * tor          ipv4         tor          ipv4         (network)
+ * ||_____      ||_____      ||_____      ||_____
+ * |      |     |      |     |      |     |      |
+ * verack ping  verack ping  verack ping  verack ping  (message type)
+ * |      |     |      |     |      |     |      |
+ * a      b     c      d     e      f     g      h
+ * @endcode
+ *
+ * If the direction and network dimensions are requested, the stats for message type are
+ * summarized and the above would become:
+ * @code
+ * sent                      recv                      (direction)
+ * ||___________             ||___________
+ * |            |            |            |
+ * tor          ipv4         tor          ipv4         (network)
+ * |            |            |            |
+ * *            *            *            *
+ * |            |            |            |
+ * a+b          c+d          e+f          g+h          (message type)
+ * @endcode
+ *
+ * This method can also rearrange results by dimension, allowing the requester to specify
+ * the order. If the message type and network dimensions are requested, the response
+ * would be:
+ * @code
+ * verack                    ping                      (message type)
+ * ||___________             ||___________
+ * |            |            |            |
+ * tor          ipv4         tor          ipv4         (network)
+ * |            |            |            |
+ * *            *            *            *
+ * |            |            |            |
+ * a+e          c+g          b+f          d+h          (direction)
+ * @endcode
+ *
+ */
+UniValue Aggregate(const std::vector<DimensionType>& dimensions, const NetStats::MultiDimensionalStats& raw_stats)
+{
+    const size_t num_dimensions = dimensions.size();
+    size_t map_depth = 1;
+
+    if (num_dimensions > 0) {
+        map_depth = num_dimensions;
+    }
+
+    MultiLevelStatsMap result{map_depth};
+
+    // Iterate over the multi dimensional array that holds the raw stats
+    for (std::size_t direction_i = 0; direction_i < NetStats::NUM_DIRECTIONS; direction_i++) {
+        for (int network_i = 0; network_i < NET_MAX; network_i++) {
+            for (std::size_t connection_i = 0; connection_i < NUM_CONNECTION_TYPES; connection_i++) {
+                for (std::size_t message_i = 0; message_i < (NUM_NET_MESSAGE_TYPES + 1); message_i++) {
+                    // a single statistic
+                    const NetStats::MsgStat& raw_stat = raw_stats[direction_i][network_i][connection_i][message_i];
+
+                    std::vector<std::string> path{};
+                    // "result" is our multi-level map, we use path to keep track of where we are as we move down it
+
+                    std::string dimension_name;
+                    // For each dimension type, get the actual name of the dimension on this stat
+                    // (i.e. the dimension name could be "tor" if the dimension type is "network")
+                    // This tells us which subtree to move into.
+                    for (unsigned int i = 0; i < num_dimensions; i++) {
+                        DimensionType dimension = dimensions[i];
+
+                        switch (dimension) {
+                        case DimensionType::MESSAGE_TYPE:
+                            dimension_name = messageTypeFromIndex(message_i);
+
+                            if (dimension_name == NET_MESSAGE_TYPE_OTHER) {
+                                dimension_name = "other"; // special case: instead of *other*
+                            }
+                            break;
+                        case DimensionType::CONNECTION_TYPE:
+                            dimension_name = ConnectionTypeAsString(NetStats::ConnectionTypeFromIndex(connection_i));
+                            break;
+                        case DimensionType::NETWORK_TYPE:
+                            dimension_name = GetNetworkName(NetStats::NetworkFromIndex(network_i));
+                            break;
+                        case DimensionType::DIRECTION:
+                            dimension_name = NetStats::DirectionAsString(NetStats::DirectionFromIndex(direction_i));
+                            break;
+                        case DimensionType::NONE:
+                            break;
+                        }
+                        path.push_back(dimension_name);
+                    }
+
+                    // If no dimensions are requested to be shown, return a single field for totals.
+                    if (path.size() == 0) {
+                        path.push_back("totals");
+                    }
+
+                    NetStats::MsgStat* v = result.get_value(path);
+
+                    // If this path does not exist in the result object, create it.
+                    if (v == nullptr) {
+                        NetStats::MsgStat msg_stat = NetStats::MsgStat{raw_stat.byte_count.load(),
+                                                                       raw_stat.msg_count.load()};
+                        v = &msg_stat;
+                        // Otherwise, retrieve the corresponding path from the result object
+                        // and add the current stat to it.
+                    } else if (raw_stat.byte_count > 0) {
+                        v->msg_count += raw_stat.msg_count;
+                        v->byte_count += raw_stat.byte_count;
+                    }
+                }
+            }
+        }
+    }
+    return result.to_univalue();
+}
+
+}; // namespace net_stats
 
 static RPCHelpMan getnettotals()
 {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -717,7 +717,189 @@ UniValue Aggregate(const std::vector<DimensionType>& dimensions, const NetStats:
     return result.to_univalue();
 }
 
+static std::vector<RPCResult> NetMsgStat()
+{
+    return {
+        {RPCResult::Type::NUM, "message_count", "Total number of messages sent"},
+        {RPCResult::Type::NUM, "byte_count", "Total number of bytes sent"}};
+}
 }; // namespace net_stats
+
+static RPCHelpMan getnetmsgstats()
+{
+    return RPCHelpMan{
+        /*name=*/"getnetmsgstats",
+        /*description=*/
+        "\nReturns the message count and total number of bytes for network traffic.\n"
+        "Results may optionally be grouped so only certain dimensions are shown.",
+        /*args=*/
+        {
+            {
+                /*name=*/"show_only",
+                /*type=*/RPCArg::Type::ARR,
+                /*fallback=*/RPCArg::Optional::OMITTED,
+                /*description=*/"An array of dimensions to arrange results by.",
+                /*inner=*/{
+                    {
+                        /*name=*/"dimension_type",
+                        /*type=*/RPCArg::Type::STR,
+                        /*fallback=*/RPCArg::Optional::OMITTED,
+                        /*description=*/"Dimension type to arrange results by.\n"
+                        "Valid options are: direction, network, connection_type, and message_type"
+                    }
+                }
+            }
+        },
+        /*results=*/{
+            // A return object with one level of data: either when totals are returned (no dimensions),
+            // or one dimension has been specified
+            RPCResult {
+                /*type=*/RPCResult::Type::OBJ_DYN,
+                /*m_key_name=*/"",
+                /*description=*/"",
+                /*inner=*/{
+                    {
+                        /*type=*/RPCResult::Type::OBJ,
+                        /*m_key_name=*/"totals",
+                        /*optional=*/true,
+                        /*description=*/"Network traffic statistics.\n"
+                            "When a message, connection, network type, or direction is not listed,\n"
+                            "the statistics for that type are 0. Only known message,\n"
+                            "connection, and network types can appear as keys in the object.",
+                        /*inner=*/net_stats::NetMsgStat()
+                    },
+                    {
+                        /*type=*/RPCResult::Type::OBJ_DYN,
+                        /*m_key_name=*/"keys for the dimension type",
+                        /*optional=*/true,
+                        /*description=*/"Network traffic statistics.\n"
+                            "When a message, connection, network type, or direction is not listed,\n"
+                            "the statistics for that type are 0. Only known message,\n"
+                            "connection, and network types can appear as keys in the object.",
+                        /*inner=*/net_stats::NetMsgStat()
+                    }
+                }
+            },
+            // A return object with two levels of data: two dimensions
+            RPCResult {
+                /*type=*/RPCResult::Type::OBJ_DYN,
+                /*m_key_name=*/"",
+                /*description=*/"",
+                /*inner=*/{
+                    {
+                        /*type=*/RPCResult::Type::OBJ_DYN,
+                        /*m_key_name=*/"keys for the first dimension type",
+                        /*description=*/"Network traffic statistics.\n"
+                            "When a message, connection, network type, or direction is not listed,\n"
+                            "the statistics for that type are 0. Only known message,\n"
+                            "connection, and network types can appear as keys in the object.",
+                        /*inner=*/{
+                            {
+                                /*type=*/RPCResult::Type::OBJ_DYN,
+                                /*m_key_name=*/"keys for the second dimension type",
+                                /*description=*/"",
+                                /*inner=*/net_stats::NetMsgStat()
+                            }
+                        }
+                    }
+                }
+            },
+            // A return object with three levels of data: three dimensions
+            RPCResult {
+                /*type=*/RPCResult::Type::OBJ_DYN,
+                /*m_key_name=*/"",
+                /*description=*/"",
+                /*inner=*/{
+                    {
+                        /*type=*/RPCResult::Type::OBJ_DYN,
+                        /*m_key_name=*/"keys for the first dimension type",
+                        /*description=*/"Network traffic statistics.\n"
+                            "When a message, connection, network type, or direction is not listed,\n"
+                            "the statistics for that type are 0. Only known message,\n"
+                            "connection, and network types can appear as keys in the object.",
+                        /*inner=*/{
+                            {
+                                /*type=*/RPCResult::Type::OBJ_DYN,
+                                /*m_key_name=*/"keys for the second dimension type",
+                                /*description=*/"",
+                                /*inner=*/{
+                                    {
+                                        /*type=*/RPCResult::Type::OBJ_DYN,
+                                        /*m_key_name=*/"keys for the third dimension type",
+                                        /*description=*/"",
+                                        /*inner=*/net_stats::NetMsgStat()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            // A return object with four levels of data: four dimensions
+            RPCResult {
+                /*type=*/RPCResult::Type::OBJ_DYN,
+                /*m_key_name=*/"",
+                /*description=*/"",
+                /*inner=*/{
+                    {
+                        /*type=*/RPCResult::Type::OBJ_DYN,
+                        /*m_key_name=*/"keys for the first dimension type",
+                        /*description=*/"Network traffic statistics.\n"
+                            "When a message, connection, network type, or direction is not listed,\n"
+                            "the statistics for that type are 0. Only known message,\n"
+                            "connection, and network types can appear as keys in the object.",
+                        /*inner=*/{
+                            {
+                                /*type=*/RPCResult::Type::OBJ_DYN,
+                                /*m_key_name=*/"keys for the second dimension type",
+                                /*description=*/"",
+                                /*inner=*/{
+                                    {
+                                        /*type=*/RPCResult::Type::OBJ_DYN,
+                                        /*m_key_name=*/"keys for the third dimension type",
+                                        /*description=*/"",
+                                        /*inner=*/{
+                                            {
+                                                /*type=*/RPCResult::Type::OBJ_DYN,
+                                                /*m_key_name=*/"keys for the fourth dimension type",
+                                                /*description*/"",
+                                                /*inner*/net_stats::NetMsgStat()
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        /*examples=*/
+        RPCExamples {
+            HelpExampleCli("getnetmsgstats", "") +
+            HelpExampleCli("getnetmsgstats", R"('["connection_type","message_type"]')") +
+            HelpExampleRpc("getnetmsgstats", "") +
+            HelpExampleRpc("getnetmsgstats", R"(["message_type","network"])")},
+        /*fun=*/[&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            NodeContext& node = EnsureAnyNodeContext(request.context);
+            const CConnman& connman = EnsureConnman(node);
+            std::vector<net_stats::DimensionType> dimensions;
+
+            // Aggregate the messages to show only requested dimensions
+            if (request.params[0].isArray()) {
+                const UniValue raw_dimensions = request.params[0].get_array();
+
+                for (unsigned int i = 0; i < raw_dimensions.size(); ++i) {
+                    std::string dimension_string = raw_dimensions[i].get_str();
+                    net_stats::DimensionType dimension = net_stats::StringToDimensionType(dimension_string);
+                    dimensions.push_back(dimension);
+                }
+            }
+
+            UniValue obj = net_stats::Aggregate(dimensions, connman.GetNetStats().m_data);
+            return obj;
+        }};
+}
 
 static RPCHelpMan getnettotals()
 {
@@ -1185,6 +1367,7 @@ void RegisterNetRPCCommands(CRPCTable& t)
         {"network", &addnode},
         {"network", &disconnectnode},
         {"network", &getaddednodeinfo},
+        {"network", &getnetmsgstats},
         {"network", &getnettotals},
         {"network", &getnetworkinfo},
         {"network", &setban},

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -129,6 +129,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getmempoolentry",
     "getmempoolinfo",
     "getmininginfo",
+    "getnetmsgstats",
     "getnettotals",
     "getnetworkhashps",
     "getnetworkinfo",

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -66,7 +66,8 @@ void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_by
 {
     assert(node.ReceiveMsgBytes(msg_bytes, complete));
     if (complete) {
-        node.MarkReceivedMsgsForProcessing();
+        NetStats net_stats = NetStats(m_net_stats);
+        node.MarkReceivedMsgsForProcessing(net_stats);
     }
 }
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -13,14 +13,17 @@ import time
 
 import test_framework.messages
 from test_framework.p2p import (
+    P2PDataStore,
     P2PInterface,
     P2P_SERVICES,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
+    assert_array_result,
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
     p2p_port,
 )
@@ -60,6 +63,7 @@ class NetTest(BitcoinTestFramework):
         self.test_connection_count()
         self.test_getpeerinfo()
         self.test_getnettotals()
+        self.test_getnetmsgstats()
         self.test_getnetworkinfo()
         self.test_getaddednodeinfo()
         self.test_service_flags()
@@ -168,12 +172,111 @@ class NetTest(BitcoinTestFramework):
             self.wait_until(lambda: peer_after()['bytesrecv_per_msg'].get('pong', 0) >= peer_before['bytesrecv_per_msg'].get('pong', 0) + 32, timeout=1)
             self.wait_until(lambda: peer_after()['bytessent_per_msg'].get('ping', 0) >= peer_before['bytessent_per_msg'].get('ping', 0) + 32, timeout=1)
 
+    def test_getnetmsgstats(self):
+        self.log.info("Test getnetmsgstats")
+
+        # Remove all P2P connections to avoid random/unpredictable packets (e.g. ping)
+        # messing with the tests below.
+        self.disconnect_nodes(0, 1)
+        node0 = self.nodes[0]
+        assert_equal(len(node0.getpeerinfo()), 0)
+
+        # Compare byte count with what getnettotals returns
+        getnettotals_response = self.nodes[0].getnettotals()
+        getnetmsgstats_response = self.nodes[0].getnetmsgstats()
+
+        assert_equal(getnettotals_response['totalbytessent'] + getnettotals_response['totalbytesrecv'],
+                     getnetmsgstats_response['totals']['byte_count'])
+
+        # Test aggregation of results by trying out a few different combinations
+        getnetmsgstats_msgtype = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])
+        assert_array_result([getnetmsgstats_msgtype['sent']['ping']], {'message_count': 4}, {'byte_count': 128})
+        assert_array_result([getnetmsgstats_msgtype['received']['pong']], {'message_count': 4}, {'byte_count': 128})
+
+        getnetmsgstats_conntype_msgtype = self.nodes[0].getnetmsgstats(show_only=["direction", "connection_type", "message_type"])
+        assert_array_result([getnetmsgstats_conntype_msgtype['received']['manual']['pong']], {'message_count': 2}, {'byte_count': 64})
+
+        getnetmsgstats_conntype_msgtype_network = self.nodes[0].getnetmsgstats(show_only=["direction", "connection_type",
+                                                                                             "message_type", "network"])
+        manualconn_sendaddrv2_stats = [{'message_count': 1}, {'byte_count': 24}]
+        assert_array_result([getnetmsgstats_conntype_msgtype_network['sent']['manual']['sendaddrv2']['not_publicly_routable']],
+            manualconn_sendaddrv2_stats[0], manualconn_sendaddrv2_stats[1])
+
+        # stats should be the same as the previous test, even with the dimension types reordered
+        getnetmsgstats_network_conntype_msgtype = self.nodes[0].getnetmsgstats(show_only=["direction", "network",
+                                                                                             "connection_type", "message_type"])
+        assert_array_result([getnetmsgstats_network_conntype_msgtype['sent']['not_publicly_routable']['manual']['sendaddrv2']],
+            manualconn_sendaddrv2_stats[0], manualconn_sendaddrv2_stats[1])
+
+        # check that the breakdown of sent ping messages matches the results that only show message type
+        getnetmsgstats_msgtype_conntype = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type", "connection_type"])
+        sent_ping_inbound = getnetmsgstats_msgtype_conntype['sent']['ping']['inbound']
+        sent_ping_manual = getnetmsgstats_msgtype_conntype['sent']['ping']['manual']
+        assert_equal(sent_ping_inbound['message_count'] + sent_ping_manual['message_count'],
+            getnetmsgstats_msgtype['sent']['ping']['message_count'])
+        assert_equal(sent_ping_inbound['byte_count'] + sent_ping_manual['byte_count'],
+            getnetmsgstats_msgtype['sent']['ping']['byte_count'])
+
+        # Test that message and byte counts increment when a ping message is sent
+        total_sent_ping_stats = getnetmsgstats_msgtype['sent']['ping']
+        total_received_pong_stats = getnetmsgstats_msgtype['received']['pong']
+
+        # Reconnect to peers 0 and 1
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
+        assert_equal(len(node0.getpeerinfo()), 2)
+
+        # ping() sends a ping to all other nodes, so message count increases by at least two pings.
+        # One for peer0 and one for peer1
+        self.nodes[0].ping()
+        self.wait_until(lambda: (self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])
+                                 ['sent']['ping']['message_count'] >= total_sent_ping_stats['message_count'] + 1), timeout=1)
+        self.wait_until(lambda: (self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])
+                                 ['received']['pong']['message_count'] >= total_received_pong_stats['message_count'] + 1), timeout=1)
+
+        getnetmsgstats_sent_ping = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])['sent']['ping']
+        assert_greater_than_or_equal(getnetmsgstats_sent_ping['byte_count'], total_sent_ping_stats['byte_count'] + 2 * 32)
+
+        getnetmsgstats_received_pong = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])['received']['pong']
+        assert_greater_than_or_equal(getnetmsgstats_received_pong['byte_count'], total_received_pong_stats['byte_count'] + 2 * 32)
+
+        # Test that when a message is broken in two, the stats only update once the full message has been received
+        # Create valid message for another node to send to me
+        conn = self.nodes[0].add_p2p_connection(P2PDataStore())
+        ping_msg = conn.build_message(test_framework.messages.msg_ping(nonce=12345))
+        cut_pos = 12  # Chosen at an arbitrary position within the header
+        # Send message in two pieces
+        getnettotals_before_partial_ping = self.nodes[0].getnettotals()['totalbytesrecv']
+        netmsgstats_before_partial_ping = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])['received']['ping']
+
+        conn.send_raw_message(ping_msg[:cut_pos])
+        # getnettotals gets updated even for partial messages
+        self.wait_until(lambda: self.nodes[0].getnettotals()['totalbytesrecv'] > getnettotals_before_partial_ping)
+        getnettotals_partial_ping = self.nodes[0].getnettotals()['totalbytesrecv']
+        # If this assert fails, we've hit an unlikely race
+        # where the test framework sent a message in between the two halves
+        assert_equal(getnettotals_partial_ping, getnettotals_before_partial_ping + cut_pos)
+
+        # check that getnetmsgstats did not update
+        getnetmsgstats_after_partial_ping = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])['received']['ping']
+        assert_equal(getnetmsgstats_after_partial_ping['message_count'], netmsgstats_before_partial_ping['message_count'])
+        assert_equal(getnetmsgstats_after_partial_ping['byte_count'], netmsgstats_before_partial_ping['byte_count'])
+
+        # send the rest of the ping
+        conn.send_raw_message(ping_msg[cut_pos:])
+        self.wait_until(lambda: self.nodes[0].getnettotals()['totalbytesrecv'] > getnettotals_partial_ping)
+        getnetmsgstats_finished_ping = self.nodes[0].getnetmsgstats(show_only=["direction", "message_type"])['received']['ping']
+        assert_equal(getnetmsgstats_finished_ping['message_count'], netmsgstats_before_partial_ping['message_count'] + 1)
+        assert_equal(getnetmsgstats_finished_ping['byte_count'], netmsgstats_before_partial_ping['byte_count'] + 32)
+
+        conn.sync_with_ping(timeout=1)
+
     def test_getnetworkinfo(self):
         self.log.info("Test getnetworkinfo")
         info = self.nodes[0].getnetworkinfo()
         assert_equal(info['networkactive'], True)
-        assert_equal(info['connections'], 2)
-        assert_equal(info['connections_in'], 1)
+        assert_equal(info['connections'], 3)
+        assert_equal(info['connections_in'], 2)
         assert_equal(info['connections_out'], 1)
 
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: false\n']):


### PR DESCRIPTION
This PR reflects phase IV of my work for https://github.com/bitcoin/bitcoin/issues/26337

It includes a new `getnetmsgstats` RPC, which supports arranging results by several different kinds of dimensions (msgtype, conntype, network, etc.) in any order. 

## Examples

Below are some examples on how the new `getnetmsgstats` RPC can be used.

<details>
  <summary>getnetmsgstats</summary>

```
 ./src/bitcoin-cli getnetmsgstats
{
  "totals": {
    "message_count": 1905,
    "byte_count": 818941962
  }
}
```
</details>

<details>
<summary>getnetmsgstats '["conntype","msgtype"]'</summary>

```
./src/bitcoin-cli getnetmsgstats '["conntype","msgtype"]'
{
  "block-relay-only": {
    "addrv2": {
      "message_count": 1,
      "byte_count": 40
    },
    "block": {
      "message_count": 6,
      "byte_count": 9899426
    },
    "cmpctblock": {
      "message_count": 1,
      "byte_count": 16615
    },
    "feefilter": {
      "message_count": 1,
      "byte_count": 32
    },
    "getdata": {
      "message_count": 1,
      "byte_count": 241
    },
    "getheaders": {
      "message_count": 4,
      "byte_count": 4212
    },
    "headers": {
      "message_count": 10,
      "byte_count": 1303
    },
    "inv": {
      "message_count": 6,
      "byte_count": 366
    },
    "ping": {
      "message_count": 4,
      "byte_count": 128
    },
    "pong": {
      "message_count": 4,
      "byte_count": 128
    },
    "sendaddrv2": {
      "message_count": 4,
      "byte_count": 96
    },
    "sendcmpct": {
      "message_count": 6,
      "byte_count": 198
    },
    "sendheaders": {
      "message_count": 4,
      "byte_count": 96
    },
    "verack": {
      "message_count": 4,
      "byte_count": 96
    },
    "version": {
      "message_count": 4,
      "byte_count": 507
    },
    "wtxidrelay": {
      "message_count": 4,
      "byte_count": 96
    }
  },
  "outbound-full-relay": {
    "addr": {
      "message_count": 6,
      "byte_count": 30302
    },
    "addrv2": {
      "message_count": 10,
      "byte_count": 76016
    },
    "blocktxn": {
      "message_count": 1,
      "byte_count": 1288086
    },
    "cmpctblock": {
      "message_count": 1,
      "byte_count": 16615
    },
    "feefilter": {
      "message_count": 15,
      "byte_count": 480
    },
    "getaddr": {
      "message_count": 8,
      "byte_count": 192
    },
    "getblocktxn": {
      "message_count": 1,
      "byte_count": 2515
    },
    "getdata": {
      "message_count": 79,
      "byte_count": 16951
    },
    "getheaders": {
      "message_count": 15,
      "byte_count": 15795
    },
    "headers": {
      "message_count": 20,
      "byte_count": 2039
    },
    "inv": {
      "message_count": 134,
      "byte_count": 58826
    },
    "notfound": {
      "message_count": 7,
      "byte_count": 787
    },
    "other": {
      "message_count": 6,
      "byte_count": 438
    },
    "ping": {
      "message_count": 15,
      "byte_count": 480
    },
    "pong": {
      "message_count": 14,
      "byte_count": 448
    },
    "sendaddrv2": {
      "message_count": 10,
      "byte_count": 240
    },
    "sendcmpct": {
      "message_count": 19,
      "byte_count": 627
    },
    "sendheaders": {
      "message_count": 14,
      "byte_count": 336
    },
    "tx": {
      "message_count": 398,
      "byte_count": 211333
    },
    "verack": {
      "message_count": 16,
      "byte_count": 384
    },
    "version": {
      "message_count": 17,
      "byte_count": 2151
    },
    "wtxidrelay": {
      "message_count": 10,
      "byte_count": 240
    }
  }
}
```
</details>


<details>
<summary>getnetmsgstats '["network", "direction", "connection_type", "message_type"]'</summary>

```
./src/bitcoin-cli getnetmsgstats '["network", "direction", "connection_type", "message_type"]'
{
  "ipv4": {
    "received": {
      "block-relay-only": {
        "addrv2": {
          "message_count": 5,
          "byte_count": 227
        },
        "block": {
          "message_count": 6,
          "byte_count": 9899426
        },
        "cmpctblock": {
          "message_count": 2,
          "byte_count": 25184
        },
        "feefilter": {
          "message_count": 1,
          "byte_count": 32
        },
        "getheaders": {
          "message_count": 2,
          "byte_count": 2106
        },
        "headers": {
          "message_count": 6,
          "byte_count": 1041
        },
        "inv": {
          "message_count": 3,
          "byte_count": 183
        },
        "ping": {
          "message_count": 6,
          "byte_count": 192
        },
        "pong": {
          "message_count": 6,
          "byte_count": 192
        },
        "sendaddrv2": {
          "message_count": 2,
          "byte_count": 48
        },
        "sendcmpct": {
          "message_count": 3,
          "byte_count": 99
        },
        "sendheaders": {
          "message_count": 2,
          "byte_count": 48
        },
        "verack": {
          "message_count": 2,
          "byte_count": 48
        },
        "version": {
          "message_count": 2,
          "byte_count": 253
        },
        "wtxidrelay": {
          "message_count": 2,
          "byte_count": 48
        }
      },
      "outbound-full-relay": {
        "addr": {
          "message_count": 4,
          "byte_count": 30222
        },
        "addrv2": {
          "message_count": 26,
          "byte_count": 148422
        },
        "blocktxn": {
          "message_count": 2,
          "byte_count": 3752987
        },
        "cmpctblock": {
          "message_count": 2,
          "byte_count": 25184
        },
        "feefilter": {
          "message_count": 11,
          "byte_count": 352
        },
        "getdata": {
          "message_count": 24,
          "byte_count": 2184
        },
        "getheaders": {
          "message_count": 11,
          "byte_count": 11583
        },
        "headers": {
          "message_count": 20,
          "byte_count": 2120
        },
        "inv": {
          "message_count": 275,
          "byte_count": 116207
        },
        "notfound": {
          "message_count": 9,
          "byte_count": 981
        },
        "other": {
          "message_count": 44,
          "byte_count": 3430
        },
        "ping": {
          "message_count": 20,
          "byte_count": 640
        },
        "pong": {
          "message_count": 20,
          "byte_count": 640
        },
        "sendaddrv2": {
          "message_count": 9,
          "byte_count": 216
        },
        "sendcmpct": {
          "message_count": 18,
          "byte_count": 594
        },
        "sendheaders": {
          "message_count": 11,
          "byte_count": 264
        },
        "tx": {
          "message_count": 1161,
          "byte_count": 596142
        },
        "verack": {
          "message_count": 12,
          "byte_count": 288
        },
        "version": {
          "message_count": 12,
          "byte_count": 1536
        },
        "wtxidrelay": {
          "message_count": 9,
          "byte_count": 216
        }
      }
    },
    "sent": {
      "block-relay-only": {
        "getdata": {
          "message_count": 1,
          "byte_count": 241
        },
        "getheaders": {
          "message_count": 2,
          "byte_count": 2106
        },
        "headers": {
          "message_count": 6,
          "byte_count": 474
        },
        "inv": {
          "message_count": 3,
          "byte_count": 183
        },
        "ping": {
          "message_count": 6,
          "byte_count": 192
        },
        "pong": {
          "message_count": 6,
          "byte_count": 192
        },
        "sendaddrv2": {
          "message_count": 2,
          "byte_count": 48
        },
        "sendcmpct": {
          "message_count": 3,
          "byte_count": 99
        },
        "sendheaders": {
          "message_count": 2,
          "byte_count": 48
        },
        "verack": {
          "message_count": 2,
          "byte_count": 48
        },
        "version": {
          "message_count": 2,
          "byte_count": 254
        },
        "wtxidrelay": {
          "message_count": 2,
          "byte_count": 48
        }
      },
      "outbound-full-relay": {
        "addr": {
          "message_count": 4,
          "byte_count": 250
        },
        "addrv2": {
          "message_count": 19,
          "byte_count": 938
        },
        "feefilter": {
          "message_count": 12,
          "byte_count": 384
        },
        "getaddr": {
          "message_count": 12,
          "byte_count": 288
        },
        "getblocktxn": {
          "message_count": 2,
          "byte_count": 3883
        },
        "getdata": {
          "message_count": 249,
          "byte_count": 48813
        },
        "getheaders": {
          "message_count": 12,
          "byte_count": 12636
        },
        "headers": {
          "message_count": 13,
          "byte_count": 1297
        },
        "inv": {
          "message_count": 464,
          "byte_count": 166868
        },
        "ping": {
          "message_count": 21,
          "byte_count": 672
        },
        "pong": {
          "message_count": 20,
          "byte_count": 640
        },
        "sendaddrv2": {
          "message_count": 9,
          "byte_count": 216
        },
        "sendcmpct": {
          "message_count": 13,
          "byte_count": 429
        },
        "sendheaders": {
          "message_count": 11,
          "byte_count": 264
        },
        "tx": {
          "message_count": 44,
          "byte_count": 18966
        },
        "verack": {
          "message_count": 12,
          "byte_count": 288
        },
        "version": {
          "message_count": 13,
          "byte_count": 1651
        },
        "wtxidrelay": {
          "message_count": 9,
          "byte_count": 216
        }
      }
    }
  }
}

```
</details>

## Phases of work on this issue

- **_Phase I - PR https://github.com/satsie/bitcoin/pull/2_** 
Extend the `getnettotals` RPC to return a breakdown of bytes per message type. This breakdown is returned in the `bytessent_per_msg` part of the response.
- **_Phase II - PR https://github.com/satsie/bitcoin/pull/3_** 
Move the code from Phase I to a new RPC, `getnetmsgstats`. Index network message stats by message type x network type x connection type. Use two data structures for this, one for sent messages and one for received. Also work through the algorithm needed to aggregate stats by one or more filters.
- **_Phase III - https://github.com/satsie/bitcoin/pull/4_** 
Clean commit history. Shared with a wider audience via https://github.com/bitcoin/bitcoin/issues/26337 with the intent of getting  feedback before opening a PR to Bitcoin Core.
- **_Phase IV - this PR!_**
Incorporate [feedback gathered from Phase III](https://github.com/vasild/bitcoin/commits/getnetmsgstats). The changes probably aren't interesting to anyone unless they have been following along, but for posterity, here's what got updated:

    ### Make Enum Indices Safe and Reliable

    `src/net.cpp` contains a bunch of `*To/FromIndex()` methods that convert an enum to an index number. I’ve decided to be explicit about these conversions because enums are not guaranteed to start at zero and it’s not enough to simply associate the first value in an enum with a number. 

    To protect against potential gaps or overlaps in numbering, every single enum value must be assigned an index. This is the only way to guarantee that the numbering is safe and reliable. 

    Instead of updating the existing `Network` and `ConnectionType` enums to assign indices to each enum value, and risk unintentionally modifying the behavior of code that uses these enums, I’ve opted for the conversion methods. This also narrows the scope of the conversion methods, making changed behavior easier to spot if the indices are modified.

    I’m interested in feedback on this. The `*To/FromIndex()` methods have low review and maintenance cost, but I’m unsure if I’ve correctly evaluated the risks associated with updating the `Network` and `ConnectionType` enums <can insert an example of assigning specific indices to each enum value>. Also open to discussion on if there is a better place for these conversion methods to live.

    ----
    ### Use atomics for message and byte count

    At the most granular level, a statistic (`CConnman::NetStats::MsgStat`) contains a message count and a byte count. To prevent any kind of torn reads/writes, use `std::atomic_uint64_t` for these values. The atomic property should come for free with `std::uint64_t` on 64 bit machines, but it needs to be explicitly declared for 32 bit machines.

    ----
    ### Remove top level "total" field from response

    Only return a "totals" field if no aggregation types are specified.

    ----
    ### Add "direction" as an aggregation type

    Previously I was forcing the response to always include direction, but decided to promote it to a normal, optional dimension like the others (network, connection type, message type).

    ----
    ### Be more consistent with terminology.

    Replace the concept of "filter"/"filter_by" with "dimensions" and "show_only". Instead of calling them "StatsFilters", call them "DimensionType".

    Also some general cleanup like always returning "message_count" and "byte_count", and fully spell out the dimensions to show (i.e. "message_type" instead of "msgtype")

## Things to Consider

- ### Locking & Consistency Beyond Individual Values

    With atomics, we know we can rely on the values for individual stats like bye count and message count. However, the byte count and message count may not always match. For example, let’s say we currently have 5 messages, and 100 bytes:

    1. A new message comes in. First the byte count is incremented to 120.
    2. A request to read the stats comes in. The RPC returns message count 5 and byte count 120.
    3. The message count is incremented to 6 in response to the new message that came in at step 1.

    The read operation did not return accurate data! Unlike the torn write example for a single value, It returned data that was true for some point in time, it’s just that the values for message count and byte count were inconsistent.

    To solve this, it’s actually not enough to lock the MsgStat struct. You actually need a mutex to protect the ENTIRE MsgStat data structure.

    The trade off here isn’t attractive. A lock would halt network threads that are doing important stuff, all for the sake of consistent stats. Even for reads, we would have to stop writes. We’d end up stopping threads that are doing important things for something that is not that important.

    Another thing to consider is how often will this RPC be called? If it’s once in a blue moon, then such a mutex is probably fine. But for a live dashboard that is making a call every second, this is not acceptable.

## Acknowledgments

Big thank you to amitiuttarwar, vasild and ajtowns for helping with this in more ways than I can count! :smile: 

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
